### PR TITLE
Fix_fetchSecretPropertyValues log output.

### DIFF
--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -25,7 +25,7 @@ class KVBackend extends AbstractBackend {
    */
   _fetchSecretPropertyValues ({ externalData, roleArn }) {
     return Promise.all(externalData.map(async secretProperty => {
-      this._logger.info(`fetching secret property ${secretProperty.name} with role: ${roleArn}`)
+      this._logger.info(`fetching secret property ${secretProperty.key} with role: ${roleArn}`)
       const value = await this._get({ secretKey: secretProperty.key, roleArn })
 
       if ('property' in secretProperty || !('name' in secretProperty)) {
@@ -73,13 +73,12 @@ class KVBackend extends AbstractBackend {
       roleArn: secretDescriptor.roleArn
     })
     externalData.forEach((secretProperty, index) => {
-      if (!('property' in secretProperty) && 'name' in secretProperty) {
+      if ('name' in secretProperty || 'property' in secretProperty) {
         const value = secretPropertyValues[index]
         secretPropertyValues[index] = {}
         secretPropertyValues[index][secretProperty.name] = value
       }
-
-      Object.keys(secretPropertyValues[index]).forEach(key => {
+      Object.getOwnPropertyNames(secretPropertyValues[index]).forEach(key => {
         data[key] = (Buffer.from(secretPropertyValues[index][key], 'utf8')).toString('base64')
       })
     })

--- a/lib/backends/kv-backend.test.js
+++ b/lib/backends/kv-backend.test.js
@@ -26,7 +26,7 @@ describe('SecretsManagerBackend', () => {
       kvBackend._get = sinon.stub()
     })
 
-    it('throws an error if missing a property', async () => {
+    it('throws an error if specified property is missing in JSON secret value', async () => {
       kvBackend._get.onFirstCall().resolves('{"foo":"bar"}')
       try {
         await kvBackend._fetchSecretPropertyValues({
@@ -42,7 +42,7 @@ describe('SecretsManagerBackend', () => {
       }
     })
 
-    it('handles secrets values that are objects', async () => {
+    it('fetches specified property of a JSON secret value', async () => {
       kvBackend._get.onFirstCall().resolves('{"foo":"bar"}')
       const secretPropertyValues = await kvBackend._fetchSecretPropertyValues({
         externalData: [{
@@ -54,19 +54,29 @@ describe('SecretsManagerBackend', () => {
       expect(secretPropertyValues).to.deep.equal(['bar'])
     })
 
-    it('handles invalid JSON objects', async () => {
+    it('fetches all properties of a JSON secret value', async () => {
+      kvBackend._get.onFirstCall().resolves('{"foo":"bar","hello":"world"}')
+      const secretPropertyValues = await kvBackend._fetchSecretPropertyValues({
+        externalData: [{
+          key: 'fakePropertyKey1'
+        }]
+      })
+      expect(secretPropertyValues).to.deep.equal([{ foo: 'bar', hello: 'world' }])
+    })
+
+    it('handles invalid JSON secret value', async () => {
       kvBackend._get.onFirstCall().resolves('{')
       const secretPropertyValues = await kvBackend._fetchSecretPropertyValues({
         externalData: [{
-          key: 'mocked-key',
-          name: 'mocked-name',
-          property: 'foo'
+          key: 'fakePropertyKey1',
+          name: 'fakePropertyName1',
+          property: 'fakePropertyProperty1'
         }]
       })
       expect(secretPropertyValues).to.deep.equal([undefined])
     })
 
-    it('fetches secret property values', async () => {
+    it('fetches secret property values without a specified role', async () => {
       kvBackend._get.onFirstCall().resolves('fakePropertyValue1')
       kvBackend._get.onSecondCall().resolves('fakePropertyValue2')
 
@@ -80,12 +90,12 @@ describe('SecretsManagerBackend', () => {
         }]
       })
 
-      expect(loggerMock.info.calledWith('fetching secret property fakePropertyName1 with role: undefined')).to.equal(true)
-      expect(loggerMock.info.calledWith('fetching secret property fakePropertyName2 with role: undefined')).to.equal(true)
+      expect(loggerMock.info.calledWith('fetching secret property fakePropertyKey1 with role: undefined')).to.equal(true)
       expect(kvBackend._get.calledWith({
         secretKey: 'fakePropertyKey1',
         roleArn: undefined
       })).to.equal(true)
+      expect(loggerMock.info.calledWith('fetching secret property fakePropertyKey2 with role: undefined')).to.equal(true)
       expect(kvBackend._get.calledWith({
         secretKey: 'fakePropertyKey2',
         roleArn: undefined
@@ -108,12 +118,12 @@ describe('SecretsManagerBackend', () => {
         roleArn: 'secretDescriptiorRole'
       })
 
-      expect(loggerMock.info.calledWith('fetching secret property fakePropertyName1 with role: secretDescriptiorRole')).to.equal(true)
-      expect(loggerMock.info.calledWith('fetching secret property fakePropertyName2 with role: secretDescriptiorRole')).to.equal(true)
+      expect(loggerMock.info.calledWith('fetching secret property fakePropertyKey1 with role: secretDescriptiorRole')).to.equal(true)
       expect(kvBackend._get.calledWith({
         secretKey: 'fakePropertyKey1',
         roleArn: 'secretDescriptiorRole'
       })).to.equal(true)
+      expect(loggerMock.info.calledWith('fetching secret property fakePropertyKey2 with role: secretDescriptiorRole')).to.equal(true)
       expect(kvBackend._get.calledWith({
         secretKey: 'fakePropertyKey2',
         roleArn: 'secretDescriptiorRole'
@@ -147,8 +157,8 @@ describe('SecretsManagerBackend', () => {
         .resolves([
           'fakePropertyValue1',
           'fakePropertyValue2',
-          { foo: 'bar' },
-          { fizz: 'buzz' },
+          'bar',
+          'buzz',
           { hello: 'world', howdy: 'do' }
         ])
 
@@ -198,8 +208,8 @@ describe('SecretsManagerBackend', () => {
       expect(manifestData).deep.equals({
         fakePropertyName1: 'ZmFrZVByb3BlcnR5VmFsdWUx', // base 64 value
         fakePropertyName2: 'ZmFrZVByb3BlcnR5VmFsdWUy', // base 64 value
-        foo: 'YmFy', // base 64 value
-        fizz: 'YnV6eg==', // base 64 value
+        fakePropertyName3: 'YmFy', // base 64 value
+        undefined: 'YnV6eg==', // base 64 value
         hello: 'd29ybGQ=', // base 64 value
         howdy: 'ZG8=' // base 64 value
       })


### PR DESCRIPTION
Fix  getSecretManifestData boolean logic.
Use Object.getOwnPropertyNames
Expand and improve tests.